### PR TITLE
Make the content columns LONGTEXT.

### DIFF
--- a/source/database.sql
+++ b/source/database.sql
@@ -11,7 +11,7 @@ CREATE TABLE IF NOT EXISTS `pwl-cache` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
   `test_list` int(2) NOT NULL DEFAULT '0',
   `timestamp` int(10) NOT NULL,
-  `content` text NOT NULL,
+  `content` longtext NOT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `timestamp` (`timestamp`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=143 ;
@@ -20,7 +20,7 @@ CREATE TABLE IF NOT EXISTS `pwl-cache-v2apps` (
   `ID` int(11) NOT NULL AUTO_INCREMENT,
   `name` varchar(10) NOT NULL,
   `timestamp` int(10) NOT NULL,
-  `content` text NOT NULL,
+  `content` longtext NOT NULL,
   PRIMARY KEY (`ID`),
   UNIQUE KEY `timestamp` (`timestamp`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=latin1 AUTO_INCREMENT=61 ;


### PR DESCRIPTION
The `pwl-cache` value has grown to exceed 2^16 bytes and can
no longer be stored in the TEXT type.

The `pwl-cache-v2apps` was updated to match the others.

To upgrade existing DBs run:

```
ALTER TABLE `pwl-cache` MODIFY content LONGTEXT;
ALTER TABLE `pwl-cache-v2apps` MODIFY content LONGTEXT;
```
